### PR TITLE
Update cmake.yml

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
     - name: Install nanogui dependencies (ubuntu)
-      run: sudo apt-get install cmake xorg-dev libglu1-mesa-dev
+      run: sudo apt-get update && sudo apt-get install cmake xorg-dev libglu1-mesa-dev
       if: matrix.os == 'ubuntu-latest'
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
Call apt-get update before installing


According to documentation:

> Note: Always run sudo apt-get update before installing a package. In case the apt index is stale, this command fetches and re-indexes any available packages, which helps prevent package installation failures.

Source: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners